### PR TITLE
fix wrong CANAL repo url

### DIFF
--- a/_tools/CANAL.md
+++ b/_tools/CANAL.md
@@ -7,7 +7,7 @@ target: LLVM IR
 technique: Formal
 guarantees: sound
 available: true
-repo: https://github.com/canalcache/cana
+repo: https://github.com/canalcache/canal
 papers:
  - name: "CANAL: a cache timing analysis framework via LLVM transformation"
    link: https://dl.acm.org/doi/10.1145/3238147.3240485


### PR DESCRIPTION
I just found out that the repository URL of the tool CANAL is spelled incorrectly, so  I corrected it.