### PR TITLE
fix: inaccurate mention of K-S in dudect

### DIFF
--- a/_tools/dudect.md
+++ b/_tools/dudect.md
@@ -17,7 +17,7 @@ papers:
 
 ## Description
 
-**dudect** is a dynamic tool that uses leakage assessment techniques from physical (power and EM) side-channel analysis, namely test-vector leakage assessment (TVLA). It first runs the target using two classes of secret input data with varying public input data and measures the duration of execution for each run. It then applies a test to the two distributions of the duration of execution for the two classes (either Welch's t-test for equality of means or Kolmogorov-Smirnov test for equality of distributions), and if the distributions differ, leakage is reported. This is analogous to how leakage assessment is used in power side-channel attacks, in that instead of comparing distributions of power consumption at points during the execution of the target, the runtime distributions are compared.
+**dudect** is a dynamic tool that uses leakage assessment techniques from physical (power and EM) side-channel analysis, namely test-vector leakage assessment (TVLA). It first runs the target using two classes of secret input data with varying public input data and measures the duration of execution for each run. It then applies a Welch t-test for equality of means to the two distributions of the duration of execution for the two classes, and if the t-test comes back larger than some preset threshold, leakage is reported. This is analogous to how leakage assessment is used in power side-channel attacks, in that instead of comparing distributions of power consumption at points during the execution of the target, the runtime distributions are compared.
 
 ## Abstract
 


### PR DESCRIPTION
The description of dudect mentions Kolmogorov-Smirnov as a possible test, but while this is mention as a potential alternative in the dudect paper, the dudect implementation doesn't implement K-S, and only uses Welch's t-test.